### PR TITLE
Some optimization experimentation

### DIFF
--- a/transpiler/src/main.rs
+++ b/transpiler/src/main.rs
@@ -69,7 +69,7 @@ pub struct YulFile {
 
 fn read_yul_contracts() -> Vec<YulFile> {
     let mut yul_files: Vec<YulFile> = Vec::new();
-    let mut paths: Vec<_> = fs::read_dir("./contracts/")
+    let mut paths: Vec<_> = fs::read_dir("../contracts/")
         .unwrap()
         .map(|r| r.unwrap())
         .collect();

--- a/transpiler/src/main.rs
+++ b/transpiler/src/main.rs
@@ -69,7 +69,7 @@ pub struct YulFile {
 
 fn read_yul_contracts() -> Vec<YulFile> {
     let mut yul_files: Vec<YulFile> = Vec::new();
-    let mut paths: Vec<_> = fs::read_dir("../contracts/")
+    let mut paths: Vec<_> = fs::read_dir("./contracts/")
         .unwrap()
         .map(|r| r.unwrap())
         .collect();

--- a/transpiler/src/miden_generator.rs
+++ b/transpiler/src/miden_generator.rs
@@ -1,11 +1,86 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::types::*;
 
+#[derive(Default)]
 struct Context {
     variables: HashMap<String, u32>,
     indentation: u32,
     next_open_memory_address: u32,
+    stack: Stack,
+}
+
+type StackValue = HashSet<String>;
+
+#[derive(Default, Clone)]
+struct Stack(Vec<StackValue>);
+
+impl std::fmt::Debug for Stack {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(for value in self.0.iter() {
+            write!(f, "{:?}\n", value);
+        })
+    }
+}
+
+type MidenInstruction = String;
+
+impl Stack {
+    // ex if `x := y`, we can keep track of that on our stack
+    fn equate_reference(&mut self, x: &str, y: &str) {
+        let stack_value = self.0.iter_mut().find(|sv| sv.contains(y)).unwrap();
+        stack_value.insert(x.to_string());
+    }
+
+    fn target(&mut self, target_stack: Stack) -> Vec<MidenInstruction> {
+        let mut instructions = vec![];
+        for v in target_stack.0.iter().rev() {
+            // TODO: can do a no-op or padding op if no identifiers
+            instructions.append(dbg!(&mut self.push_refs_to_top(v)));
+        }
+        return instructions;
+    }
+
+    fn add_unknown(&mut self) {
+        self.0.insert(0, HashSet::new());
+    }
+
+    fn push_ref_to_top(&mut self, identifier: &str) -> Vec<MidenInstruction> {
+        let mut identifiers = HashSet::new();
+        identifiers.insert(identifier.to_string());
+        self.push_refs_to_top(&identifiers)
+    }
+
+    fn push_refs_to_top(&mut self, identifiers: &HashSet<String>) -> Vec<MidenInstruction> {
+        // TODO: need to figure out what to do when we're targeting a stack that has stack values
+        // w/ multiple references, there are probably cases that fail currently, where variables
+        // are equal to each other before a for loop but not after
+        let location = self
+            .0
+            .iter()
+            .position(|sv| identifiers.is_subset(sv))
+            .unwrap();
+        let duped = self.0.get(location).unwrap().clone();
+        self.0.insert(0, duped);
+        return vec![format!("dup.{}", location)];
+    }
+
+    fn push(&mut self, value: u32) -> Vec<MidenInstruction> {
+        self.0.insert(0, HashSet::new());
+        return vec![format!("push.{}", value)];
+    }
+
+    fn consume(&mut self, n: u32) {
+        for _ in 0..n {
+            self.0.remove(0);
+        }
+    }
+
+    fn top_is_var(&mut self, identifier: &str) {
+        let idents = self.0.get_mut(0).unwrap();
+        idents.clear();
+        idents.insert(identifier.to_string());
+    }
 }
 
 fn declare_var(program: &mut String, op: &ExprDeclareVariable, context: &mut Context) {
@@ -14,18 +89,27 @@ fn declare_var(program: &mut String, op: &ExprDeclareVariable, context: &mut Con
     context.variables.insert(op.identifier.clone(), address);
     if let Some(rhs) = &op.rhs {
         transpile_op(&rhs, program, context);
-        add_line(program, "padw", context);
-        add_line(program, "drop", context);
-        add_line(program, &format!("mem.pop.{}", address), context);
+        context.stack.top_is_var(&op.identifier);
+        // add_line(program, "padw", context);
+        // add_line(program, "drop", context);
+        // add_line(program, &format!("mem.pop.{}", address), context);
     }
 }
 
 fn assignment(program: &mut String, op: &ExprAssignment, context: &mut Context) {
-    let address = context.variables.get(&op.identifier).unwrap().clone();
+    // TODO: in the future we should be able to just mark that two variables share the same
+    // stack address, but I can't quite figure it out for the fibonacci example currently
+    // if let Expr::Variable(ExprVariableReference {
+    //     identifier: target_ident,
+    // }) = &*op.rhs
+    // {
+    //     context
+    //         .stack
+    //         .equate_reference(&op.identifier.clone(), &target_ident);
+    // } else {
     transpile_op(&op.rhs, program, context);
-    add_line(program, "padw", context);
-    add_line(program, "drop", context);
-    add_line(program, &format!("mem.pop.{}", address), context);
+    context.stack.top_is_var(&op.identifier.clone());
+    // }
 }
 
 fn block(program: &mut String, op: &ExprBlock, context: &mut Context) {
@@ -36,35 +120,34 @@ fn block(program: &mut String, op: &ExprBlock, context: &mut Context) {
 
 fn for_loop(program: &mut String, op: &ExprForLoop, context: &mut Context) {
     block(program, &op.init_block, context);
+    let stack_target = context.stack.clone();
     transpile_op(&op.conditional, program, context);
     add_line(program, &format!("while.true"), context);
+    // Because the while.true will consume the top of the stack
+    context.stack.consume(1);
     context.indentation += 4;
     block(program, &op.interior_block, context);
     block(program, &op.after_block, context);
+    add_lines(context.stack.target(stack_target), program, context);
     transpile_op(&op.conditional, program, context);
+    // Because the while.true will consume the top of the stack
+    context.stack.consume(1);
     context.indentation -= 4;
     add_line(program, &format!("end"), context);
 }
 
-fn add(program: &mut String, op: &ExprFunctionCall, context: &mut Context) {
+fn transpile_miden_function(
+    miden_function: &str,
+    program: &mut String,
+    op: &ExprFunctionCall,
+    context: &mut Context,
+) {
     for expr in [&op.first_expr, &op.second_expr] {
         transpile_op(expr, program, context);
     }
-    add_line(program, &format!("add"), context);
-}
-
-fn mul(program: &mut String, op: &ExprFunctionCall, context: &mut Context) {
-    for expr in [&op.first_expr, &op.second_expr] {
-        transpile_op(expr, program, context);
-    }
-    add_line(program, &format!("mul"), context);
-}
-
-fn gt(program: &mut String, op: &ExprFunctionCall, context: &mut Context) {
-    for expr in [&op.first_expr, &op.second_expr] {
-        transpile_op(expr, program, context);
-    }
-    add_line(program, &format!("gt"), context);
+    context.stack.consume(2);
+    context.stack.add_unknown();
+    add_line(program, miden_function, context);
 }
 
 fn if_statement(program: &mut String, op: &ExprIfStatement, context: &mut Context) {
@@ -76,22 +159,16 @@ fn if_statement(program: &mut String, op: &ExprIfStatement, context: &mut Contex
     add_line(program, &format!("end"), context);
 }
 
-fn lt(program: &mut String, op: &ExprFunctionCall, context: &mut Context) {
-    for expr in [&op.first_expr, &op.second_expr] {
-        transpile_op(expr, program, context);
-    }
-    add_line(program, &format!("lt"), context);
-}
-
-fn insert_literal(program: &mut String, value: u128, context: &mut Context) {
-    add_line(program, &format!("push.{}", value), context);
+fn insert_literal(program: &mut String, value: u32, context: &mut Context) {
+    add_lines(context.stack.push(value), program, context);
 }
 
 fn load_variable(program: &mut String, op: &ExprVariableReference, context: &mut Context) {
-    let address = context.variables.get(&op.identifier).unwrap();
-    add_line(program, &format!("mem.push.{}", address), context);
-    add_line(program, "dup", context);
-    add_line(program, "dropw", context);
+    add_lines(
+        context.stack.push_ref_to_top(&op.identifier),
+        program,
+        context,
+    );
 }
 
 fn add_line(program: &mut String, line: &str, context: &Context) {
@@ -101,6 +178,12 @@ fn add_line(program: &mut String, line: &str, context: &Context) {
         " ".repeat(context.indentation.try_into().unwrap()),
         line
     )
+}
+
+fn add_lines(lines: Vec<MidenInstruction>, program: &mut String, context: &Context) {
+    for line in lines {
+        add_line(program, &line, context);
+    }
 }
 
 fn transpile_op(expr: &Expr, program: &mut String, context: &mut Context) {
@@ -113,19 +196,19 @@ fn transpile_op(expr: &Expr, program: &mut String, context: &mut Context) {
         Expr::Block(op) => block(program, op, context),
         Expr::IfStatement(op) => if_statement(program, op, context),
         Expr::FunctionCall(op) => {
-            if (op.function_name == "add") {
-                add(program, op, context)
-            } else if (op.function_name == "mul") {
-                mul(program, op, context)
-            } else if (op.function_name == "gt") {
-                gt(program, op, context)
-            } else if (op.function_name == "lt") {
-                lt(program, op, context)
+            // TODO: All functions are assumed to consume 2 stack elements and add one, for now
+            if op.function_name == "add" {
+                transpile_miden_function("add", program, op, context)
+            } else if op.function_name == "mul" {
+                transpile_miden_function("mul", program, op, context)
+            } else if op.function_name == "gt" {
+                transpile_miden_function("gt", program, op, context)
+            } else if op.function_name == "lt" {
+                transpile_miden_function("lt", program, op, context)
             } else {
                 todo!("Need to implement {} function in miden", op.function_name)
             }
         }
-        x => todo!("{:?} unimplemented", x),
     }
 }
 
@@ -134,6 +217,7 @@ pub fn transpile_program(expressions: Vec<Expr>) -> String {
         variables: HashMap::new(),
         next_open_memory_address: 0,
         indentation: 4,
+        stack: Stack::default(),
     };
     let mut program = "begin".to_string();
     for expr in expressions {
@@ -144,55 +228,152 @@ pub fn transpile_program(expressions: Vec<Expr>) -> String {
     return program;
 }
 
-// TESTS
+pub fn optimize_ast(ast: Vec<Expr>) -> Vec<Expr> {
+    let mut assignment_visitor = VariableAssignmentVisitor::default();
+    let ast = walk_ast(ast, &mut assignment_visitor);
+    let const_variables = assignment_visitor
+        .assignment_counter
+        .into_iter()
+        .filter(|(k, v)| *v == 1)
+        .filter_map(|(k, _)| {
+            if let Some(value) = assignment_visitor.last_assignment.get(&k) {
+                return Some((k, *value));
+            }
+            return None;
+        })
+        .collect::<HashMap<String, u32>>();
+    let ast = walk_ast(ast, &mut ConstVariableVisitor { const_variables });
+    ast
+}
 
-// #[ignore]
-// #[test]
-// fn test_add_compilation() {
-//     let mut program = "begin\npush.0\npush.0\npush.0".to_string();
-//     let ops = vec![
-//         Expr::DeclareVariable(ExprDeclareVariable {
-//             identifier: "foo".to_string(),
-//             rhs: Some(Box::new(Expr::Literal(12))),
-//         }),
-//         Expr::DeclareVariable(ExprDeclareVariable {
-//             identifier: "bar".to_string(),
-//             rhs: Some(Box::new(Expr::Literal(15))),
-//         }),
-//         Expr::FunctionCall(ExprFunctionCall {
-//             function_name: "add".to_string(),
-//             first_expr: Box::new(Expr::Variable(ExprVariableReference {
-//                 identifier: "foo".to_string(),
-//             })),
-//             second_expr: Box::new(Expr::Variable(ExprVariableReference {
-//                 identifier: "bar".to_string(),
-//             })),
-//         }),
-//     ];
-//     let mut context = Context {
-//         variables: HashMap::new(),
-//         next_open_memory_address: 1,
-//     };
-//
-//     for op in ops {
-//         transpile_op(&op, &mut program, &mut context);
-//     }
-//     add_line(&mut program, "end");
-//
-//     println!("{}", program);
-//     assert_eq!(
-//         program,
-//         "begin
-// push.0
-// push.0
-// push.0
-// push.12
-// mem.store.0
-// push.15
-// mem.store.1
-// mem.load.0
-// mem.load.1
-// add
-// end"
-//     );
-// }
+fn walk_ast<V: ExpressionVisitor>(ast: Vec<Expr>, visitor: &mut V) -> Vec<Expr> {
+    let mut new_ast = vec![];
+    for expr in ast {
+        if let Some(expr) = walk_expr(expr, visitor) {
+            new_ast.push(expr);
+        }
+    }
+    return new_ast;
+}
+
+trait ExpressionVisitor {
+    fn visit_expr(&mut self, expr: Expr) -> Option<Expr>;
+}
+
+#[derive(Default)]
+struct ConstVariableVisitor {
+    const_variables: HashMap<String, u32>,
+}
+
+#[derive(Default)]
+struct VariableAssignmentVisitor {
+    assignment_counter: HashMap<String, u32>,
+    last_assignment: HashMap<String, u32>,
+}
+
+impl ExpressionVisitor for VariableAssignmentVisitor {
+    fn visit_expr(&mut self, expr: Expr) -> Option<Expr> {
+        match &expr {
+            Expr::DeclareVariable(ExprDeclareVariable { identifier, rhs }) => {
+                if let Some(Expr::Literal(v)) = rhs.clone().map(|r| *r) {
+                    self.last_assignment.insert(identifier.clone(), v);
+                }
+                let count = self
+                    .assignment_counter
+                    .entry(identifier.clone())
+                    .or_insert(0);
+                *count += 1;
+            }
+            Expr::Assignment(ExprAssignment { identifier, rhs: _ }) => {
+                let count = self
+                    .assignment_counter
+                    .entry(identifier.clone())
+                    .or_insert(0);
+                *count += 1;
+            }
+            _ => {}
+        }
+        return Some(expr);
+    }
+}
+
+impl ExpressionVisitor for ConstVariableVisitor {
+    fn visit_expr(&mut self, expr: Expr) -> Option<Expr> {
+        match &expr {
+            Expr::DeclareVariable(ExprDeclareVariable { identifier, rhs: _ }) => {
+                if self.const_variables.get(identifier).is_some() {
+                    return None;
+                }
+            }
+            Expr::Variable(ExprVariableReference { identifier }) => {
+                if let Some(value) = self.const_variables.get(identifier) {
+                    return Some(Expr::Literal(*value));
+                }
+            }
+            _ => {}
+        }
+        return Some(expr);
+    }
+}
+
+// TODO: it would be nice if there wasn't so much cloning in here
+fn walk_expr<V: ExpressionVisitor>(expr: Expr, visitor: &mut V) -> Option<Expr> {
+    let expr = visitor.visit_expr(expr.clone());
+    if let Some(expr) = expr.clone() {
+        return Some(match expr {
+            Expr::Literal(x) => expr,
+            Expr::FunctionCall(ExprFunctionCall {
+                function_name,
+                first_expr,
+                second_expr,
+            }) => Expr::FunctionCall(ExprFunctionCall {
+                function_name,
+                first_expr: Box::new(walk_expr(*first_expr, visitor).unwrap()),
+                second_expr: Box::new(walk_expr(*second_expr, visitor).unwrap()),
+            }),
+            Expr::IfStatement(ExprIfStatement {
+                first_expr,
+                second_expr,
+            }) => Expr::IfStatement(ExprIfStatement {
+                first_expr: Box::new(walk_expr(*first_expr, visitor).unwrap()),
+                second_expr: Box::new(ExprBlock {
+                    exprs: walk_ast(second_expr.exprs, visitor),
+                }),
+            }),
+            Expr::Assignment(ExprAssignment { identifier, rhs }) => {
+                Expr::Assignment(ExprAssignment {
+                    identifier,
+                    rhs: Box::new(walk_expr(*rhs, visitor).unwrap()),
+                })
+            }
+            Expr::DeclareVariable(ExprDeclareVariable { identifier, rhs }) => {
+                Expr::DeclareVariable(ExprDeclareVariable {
+                    identifier,
+                    rhs: rhs.map(|rhs| Box::new(walk_expr(*rhs, visitor).unwrap())),
+                })
+            }
+            Expr::ForLoop(ExprForLoop {
+                init_block,
+                conditional,
+                after_block,
+                interior_block,
+            }) => Expr::ForLoop(ExprForLoop {
+                init_block: Box::new(ExprBlock {
+                    exprs: walk_ast(init_block.exprs, visitor),
+                }),
+                conditional: Box::new(walk_expr(*conditional, visitor).unwrap()),
+                after_block: Box::new(ExprBlock {
+                    exprs: walk_ast(after_block.exprs, visitor),
+                }),
+                interior_block: Box::new(ExprBlock {
+                    exprs: walk_ast(interior_block.exprs, visitor),
+                }),
+            }),
+            Expr::Block(ExprBlock { exprs }) => Expr::Block(ExprBlock {
+                exprs: walk_ast(exprs, visitor),
+            }),
+            Expr::Variable(ExprVariableReference { identifier: _ }) => expr,
+        });
+    }
+    None
+}

--- a/transpiler/src/parser.rs
+++ b/transpiler/src/parser.rs
@@ -94,7 +94,7 @@ fn parse_expression(expression: Pair<Rule>) -> Expr {
     match inner.as_rule() {
         Rule::literal => {
             let i = inner.as_str();
-            return Expr::Literal(i.parse::<u128>().unwrap());
+            return Expr::Literal(i.parse::<u32>().unwrap());
         }
         Rule::identifier => {
             return Expr::Variable(ExprVariableReference {

--- a/transpiler/src/types.rs
+++ b/transpiler/src/types.rs
@@ -1,6 +1,6 @@
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Expr {
-    Literal(u128),
+    Literal(u32),
     FunctionCall(ExprFunctionCall),
     IfStatement(ExprIfStatement),
     Assignment(ExprAssignment),


### PR DESCRIPTION
Added a couple optimizations to our miden generation, enabled by a couple new concepts.

## Stack management
The biggest optimization is around stack management. The transpiler will keep track of which slots in the stack are used for which variables, and `dup` them to the top as needed, instead of using `mem`. The catch here, is that after conditionals and after each iteration of a for loop, you have to "reset" the stack to have the same order of variables as before the conditional / for loop. For now, it just iterates through the old stack order in reverse and pushes the new variable values to the top in that order, thereby reproducing the same order as before. This can result in quite a few `dup` calls, I'm sure we could optimize this further, with some sort of diffing algorithm.

So now we should be able to handle up to 16 locals. When we hit 12 items in the stack, we should push the top variable to memory, but I haven't done this yet. I don't see it being an issue though, should be straightforward to add.

## Const-ing variables, by walking the AST
There are a class of optimizations that are enabled by us having an AST generated between parsing and transpilation. The simplest is just looking at variables that are only assigned once, to a literal, and removing the declaration, then replacing all references to it with the value it was initialized to. Ex. for this yul code:
```
let x := 42
add(x, 2)
```
The AST pre-optimization is:
```
AST
├╼ declare - x
│ └╼ 42
└╼ add()
  ├╼ var - x
  └╼ 2
```
The AST post-optimization is just:
```
AST
└╼ add()
  ├╼ 42
  └╼ 2
```

I don't think this is going to be a useful optimization, overall, because generated yul code probably already `const`s things whenever possible, but we now have a pattern and a place to add more optimizations that require looking at, and possibly modifying, the AST before generation: https://github.com/ControlCplusControlV/Scribe/blob/5d942bf527ec1ab93e1e96285f1e18869ad31ad5/transpiler/src/miden_generator.rs#L233-L249

In the code above we have one visitor that will just count how many times a variable gets assigned, and if it's assigned to a literal, keeps track of the last one. We then use a separate visitor to modify the AST, with the `const`-able variables found by the first visitor.

## Results - Fibonacci

The fibonacci example is down from 70 instructions to 26:
```
begin
    push.0
    push.1
    push.0
    push.0
    dup.0
    push.10
    lt
    while.true
        dup.3
        dup.3
        add
        dup.3
        dup.1
        dup.3
        push.1
        add
        dup.2
        dup.2
        dup.5
        dup.3
        dup.0
        push.10
        lt
    end
    dup.2
end
```
