### PR TITLE
More optimizations

### DIFF
--- a/transpiler/src/types.rs
+++ b/transpiler/src/types.rs
@@ -8,6 +8,8 @@ pub enum Expr {
     ForLoop(ExprForLoop),
     Block(ExprBlock),
     Variable(ExprVariableReference),
+    // Intermediate-AST-only expressions
+    Repeat(ExprRepeat),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -32,6 +34,12 @@ pub struct ExprForLoop {
     pub conditional: Box<Expr>,
     pub after_block: Box<ExprBlock>,
     pub interior_block: Box<ExprBlock>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ExprRepeat {
+    pub interior_block: Box<ExprBlock>,
+    pub iterations: u32,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -86,6 +94,17 @@ impl Expr {
                 let _branch = tree.add_branch(&format!("declare - {}", &identifier.to_string()));
                 if let Some(rhs) = rhs {
                     rhs.add_to_tree(tree);
+                }
+            }
+            Expr::Repeat(ExprRepeat {
+                interior_block,
+                iterations,
+            }) => {
+                let _branch = tree.add_branch(&format!("repeat {}", iterations));
+                {
+                    let _after_branch = tree.add_branch("interior block");
+                    let block = *interior_block.clone();
+                    Expr::Block(block).add_to_tree(tree);
                 }
             }
             Expr::ForLoop(ExprForLoop {


### PR DESCRIPTION
Building off the previous optimization work, a couple new ones.

## For loops -> repeat
When for loops match a particular structure, we can output `repeat.{}` instructions instead of all the cruft involved in for loops usually (init_block, conditional, after block, conditional again). 

One cool thing here is that this builds on top of the const-ing of variables from the previous optimization pass. So in the fibonacci example, this optimization wouldn't happen, if we didn't first const the `n` variable.

For now this is really fragile, it only works for for loops that declare a var to start from a constant, then check with `lt` that it is below another constant. It also doesn't detect if the iterator variable is referenced inside the for loop, but that's trivial to add.

## Equating references

When we hit a line like `a := b`, we don't actually have to do anything to the stack. So now the stack will keep track of a set of references that that slot points to, instead of duplicating that slot.

## Results

Fibonnaci has slimmed down another 50%, to 13 instructions:
```
begin
    push.0
    push.1
    push.0
    repeat.10
        dup.2
        dup.2
        add
        dup.2
        dup.1
        dup.2
    end
    dup.1
end
```